### PR TITLE
Make use of YAML role spec format; use unarchive module

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 if [ "up", "provision" ].include?(ARGV.first) &&
   !(File.directory?("roles/azavea.java") || File.symlink?("roles/azavea.java"))
 
-  unless system("ansible-galaxy install --force -r roles.txt -p roles")
+  unless system("ansible-galaxy install --force -r roles.yml -p roles")
     $stderr.puts "\nERROR: Please install Ansible 1.4.2+ so that the ansible-galaxy binary"
     $stderr.puts "is available."
     exit(1)

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,0 @@
-azavea.java,0.1.1

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,2 @@
+- name: azavea.java
+  version: 0.1.1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,9 @@
            dest=/usr/local/src/scala-{{ scala_version }}.tgz
 
 - name: Extract and install Scala
-  command: tar -C /opt -xzf /usr/local/src/scala-{{ scala_version }}.tgz
-           creates=/opt/scala-{{ scala_version }}
+  unarchive: src=/usr/local/src/scala-{{ scala_version }}.tgz
+             dest=/opt
+             copy=no
 
 - name: Symlink Scala into /usr/local/bin
   file: src=/opt/scala-{{ scala_version }}/bin/{{ item }}


### PR DESCRIPTION
The is an attempt to silence deprecation warnings in Ansible 2.0. In addition to the YAML role specification format updates, I changed an instance of the command module/tar with the unarchive module.

---

**Testing**

``` bash
$ cd examples
$ rm -rf roles/azavea.java
$ vagrant destroy -f && vagrant up
```
