### PR TITLE
new role variables to allow setting custom scala+sbt install folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ An Ansible role for installing Scala.
 
 - `scala_version` - Scala version
 - `scala_sbt_version` - SBT version
+- `scala_src_dir` - the folder containing the installer archive (default: `/usr/local/src`)
+- `scala_usr_dir` - the parent folder for the symlinks to the scala binaries (default: `/usr/local/bin`)
+- `scala_usr_orig_dir` - the parent folder for the installed scala folder (default: `/opt`)
 
 ## Testing
 Tests are done using [molecule](http://molecule.readthedocs.io/). To run the test suite, install molecule and its dependencies and run ` molecule test` from the folder containing molecule.yml. To add additional tests, add a [testinfra](http://testinfra.readthedocs.org/) python script in the [tests](./tests/) directory, or add a function to [test_scala.py](./tests/test_scala.py). Information about available Testinfra modules is available [here](http://testinfra.readthedocs.io/en/latest/modules.html).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 scala_version: "2.11.1"
 scala_sbt_version: "0.13.6"
+scala_src_dir: /usr/local/src
+scala_usr_dir: /usr/local/bin
+scala_usr_orig_dir: /opt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,17 @@
 ---
 - name: Download Scala
   get_url: url=http://www.scala-lang.org/files/archive/scala-{{ scala_version }}.tgz
-           dest=/usr/local/src/scala-{{ scala_version }}.tgz
+           dest={{ scala_src_dir }}/scala-{{ scala_version }}.tgz
 
 - name: Extract and install Scala
-  unarchive: src=/usr/local/src/scala-{{ scala_version }}.tgz
-             dest=/opt
+  unarchive: src={{ scala_src_dir }}/scala-{{ scala_version }}.tgz
+             dest={{ scala_usr_orig_dir }}
              copy=no
+             creates={{ scala_usr_orig_dir }}/scala-{{ scala_version }}
 
 - name: Symlink Scala into /usr/local/bin
-  file: src=/opt/scala-{{ scala_version }}/bin/{{ item }}
-        dest=/usr/local/bin/{{ item }}
+  file: src={{ scala_usr_orig_dir }}/scala-{{ scala_version }}/bin/{{ item }}
+        dest={{ scala_usr_dir }}/{{ item }}
         state=link
   with_items:
     - fsc
@@ -21,8 +22,8 @@
 
 - name: Download SBT package
   get_url: url=https://dl.bintray.com/sbt/debian/sbt-{{ scala_sbt_version }}.deb
-           dest=/usr/local/src/sbt-{{ scala_sbt_version }}.deb
+           dest={{ scala_src_dir }}/sbt-{{ scala_sbt_version }}.deb
 
 - name: Install SBT
-  apt: deb=/usr/local/src/sbt-{{ scala_sbt_version }}.deb
+  apt: deb={{ scala_src_dir }}/sbt-{{ scala_sbt_version }}.deb
        state=installed


### PR DESCRIPTION
replaces https://github.com/azavea/ansible-scala/pull/2
( includes an updated README  and excludes the removal/change in the java-role dependency)
